### PR TITLE
[bugsnag] Show up to 5 lines of error message

### DIFF
--- a/src/handlers/bugsnag/handler_bugsnag_out.go
+++ b/src/handlers/bugsnag/handler_bugsnag_out.go
@@ -58,9 +58,10 @@ func Normalize(cfg config.Configuration, bytes []byte) (cc.Message, error) {
 	fields := []cc.Field{}
 
 	if len(strings.TrimSpace(src.Error.Message)) > 0 {
+    errorMessage := src.Error.Message
 		fields = append(fields, cc.Field{
 			Title: "Error",
-			Value: src.Error.Message})
+      Value: string.Join(strings.Split(src.Error.Message, "\n")[:5], "\n")})
 	}
 
 	stLocations := []string{}


### PR DESCRIPTION
Hi @grokify 

I'm not sure this will work but the idea is that sometimes the error message is a full html page and it will take a lot of space. Example:

![Screenshot_2019-07-17_17-07-11](https://user-images.githubusercontent.com/1866809/61386937-7232f580-a8b5-11e9-9ba2-10d30a3194b9.png)

The idea is to limit the error message up to 5 lines. 
I do not know go so this patch is like black magic to me