### PR TITLE
Add support for templated CommonChat Handlers

### DIFF
--- a/src/handlers/templated_handler.go
+++ b/src/handlers/templated_handler.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"strings"
+	"regexp"
+    "encoding/json"
+    "strconv"
+
+	"github.com/grokify/chathooks/src/config"
+    cc "github.com/grokify/commonchat"
+    "github.com/tidwall/gjson"
+)
+
+func NewTemplatedHandler(tmpl string) Handler {
+	return Handler {
+        Normalize: getTemplatedNormalizer(tmpl),
+    }
+}
+
+func getTemplatedNormalizer(tmpl string) func(cfg config.Configuration, bytes []byte) (cc.Message, error) {
+    return func(cfg config.Configuration, bytes []byte) (cc.Message, error) {
+    	ccMsg := cc.NewMessage()
+    	src := string(bytes)
+
+        tokenPattern := regexp.MustCompile(`\${.+?}`)
+        keyPattern := regexp.MustCompile(`\${(.+?)}`)
+        formattedJson := tokenPattern.ReplaceAllStringFunc(tmpl, func(match string) string {
+            matches := keyPattern.FindStringSubmatch(match)
+            result := gjson.Get(src, strings.TrimSpace(matches[1]))
+            switch result.Type {
+            case gjson.String:
+                return result.Str
+            case gjson.Number:
+                return strconv.FormatFloat(result.Num, 'f', -1, 64)
+            case gjson.JSON:
+                return result.Raw
+            default:
+                return result.Type.String()
+            }
+        })
+
+        err := json.Unmarshal([]byte(formattedJson), &ccMsg)
+        return ccMsg, err
+    }
+}


### PR DESCRIPTION
Adds support for templated handlers to make it easier for users to extend, customize, and maintain webhook mappings. A template is simply a tokenized json string to the structure of `CommonChat.Message`.

### Using Templated Handlers - Heroku Example
Inside main.go, add a templated handler like you would with any other handler:
```go
herokuTemplatedHandler := handlers.NewTemplatedHandler(herokuTemplateString)

handlerSet := HandlerSet{Handlers: map[string]Handler{
    ...
    "heroku": hf.InflateHandler(herokuTemplatedHandler)
    ...
}}

```

`herokuTemplateString` is a string containing:
```json
{
    "icon_url": "http://grokify.github.io/chathooks/icons/icon_heroku_512x512.png",
    "activity": "Heroku Templated Webhook",
    "text": "Version #${data.version} released for app: ${data.app.name}",
    "attachments": [
        {
            "fields": [
                {
                    "title": "Author",
                    "value": "${actor.email}",
                    "short": true
                },
                {
                    "title": "Description",
                    "value": "${data.description}",
                    "short": true
                },
                {
                    "title": "Build Status",
                    "value": "${data.status}",
                    "short": true
                },
                {
                    "title": "Time",
                    "value": "${data.updated_at}",
                    "short": true
                }
            ]
        }
    ]
}
```

After receiving the following webhook...
```json
{
    "action": "update",
    "actor": {
        "email": "drew.ligman@ringcentral.com",
        "id": "982c6580-49aa-40f3-9649-41a927543b9f"
    },
    "created_at": "2019-08-30T19:48:56.064869Z",
    "data": {
        "addon_plan_names": [],
        "app": {
            "id": "62d995b9-759a-4f52-b63b-b49b0cb011ff",
            "name": "drewligman-ringcentral"
        },
        "created_at": "2019-08-30T19:48:55Z",
        "current": true,
        "description": "Set KEY config vars",
        "id": "e6191f84-d071-4115-b11e-548f80cd5f8c",
        "output_stream_url": null,
        "pstable": {},
        "slug": null,
        "status": "succeeded",
        "updated_at": "2019-08-30T19:48:55Z",
        "user": {
            "email": "drew.ligman@ringcentral.com",
            "id": "982c6580-49aa-40f3-9649-41a927543b9f"
        },
        "version": 13
    },
    "id": "1e2e9388-b9ed-4819-94e1-a646b6b3c31a",
    "previous_data": {},
    "published_at": "2019-08-30T19:48:56Z",
    "resource": "release",
    "sequence": null,
    "updated_at": "2019-08-30T19:48:56.064877Z",
    "version": "application/vnd.heroku+json; version=3",
    "webhook_metadata": {
        "attempt": {
            "id": "9977e478-a760-4f6f-906d-9f3b56d61080"
        },
        "delivery": {
            "id": "d7b33555-5c05-48d2-901f-d7a227e10a1e"
        },
        "event": {
            "id": "1e2e9388-b9ed-4819-94e1-a646b6b3c31a",
            "include": "api:release"
        },
        "webhook": {
            "id": "4c0b5d28-2fc5-4baa-82be-1f81afab2a53"
        }
    }
}
```

The handler will POST the following:
```json
{
  "icon": "http://grokify.github.io/chathooks/icons/icon_heroku_512x512.png",
  "activity": "Heroku Templated Webhook",
  "body": "Version #13 released for app: drewligman-ringcentral",
  "attachments": [
    {
      "card": "Card",
      "fields": [
        {
          "title": "Author",
          "value": "drew.ligman@ringcentral.com",
          "short": true
        },
        {
          "title": "Description",
          "value": "Set KEY config vars",
          "short": true
        },
        {
          "title": "Build Status",
          "value": "succeeded",
          "short": true
        },
        {
          "title": "Time",
          "value": "2019-08-30T19:48:55Z",
          "short": true
        }
      ]
    }
  ]
}
```

From inside Glip:
![Templated Webhook Screenshot](https://glip-vault-1.s3.amazonaws.com/web/customer_files/1444386963468/modified.PNG?Expires=2075494478&AWSAccessKeyId=AKIAJROPQDFTIHBTLJJQ&Signature=yIjJZM6yk75c2xWOHqCAkPOx%2FO4%3D)